### PR TITLE
Fix range of November possibilities

### DIFF
--- a/matlab/EV_jerseyvotes.m
+++ b/matlab/EV_jerseyvotes.m
@@ -30,7 +30,7 @@
 clear now
 today=floor(now);
 daystoelection=datenum(2020,11,3)-today; % assuming date is set correctly in machine
-MMsigma=min(0.4*sqrt(daystoelection),1.5);
+MMsigma=max(0.4*sqrt(daystoelection),1.5);
 
 Mrange=[-2*MMsigma:0.1:2*MMsigma];% cover range of +/-2*MMsigma
 nowdensity=tpdf(Mrange/MMsigma,3); % long-tailed distribution. you never know.


### PR DESCRIPTION
The variable MMsigma/MMdrift sets a range of possibilities to integrate over. This stabilizes the jerseyvotes calculation. For long times, the range should be wider - with a floor. The max() function does that. For some reason I set it to min(). Probably not enough coffee. :-P now matches similar calculations elsewhere, for example line in in EV_prediction.m