### PR TITLE
Update main.py for Presidential meta-margin

### DIFF
--- a/python_graphics/main.py
+++ b/python_graphics/main.py
@@ -45,7 +45,7 @@ generate_line_plot(
         data_file='EV_estimate_history.csv',
         x_column='date',
         y_column='meta_margin',
-        ylim=(-1, 7),
+        ylim=(-1, 9),
         ylab_txt='Meta-margin',
         ylab_pad=0.05,
         ylab_rotation=90,


### PR DESCRIPTION
Raising limit of Presidential meta-margin. It would be nice for this to be something like max(8,math.ceil(max_meta_margin+0.1)), or however one would write the 8 or the meta-margin plus 0.1 ceilinged to the nearest integer, whichever is larger. But this will do.